### PR TITLE
special-case bundle-dylibs.sh in .editorconfig (to preserve upstream indentation)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,6 +33,10 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[utils/macos/bundle-dylibs.sh]
+indent_size = 4
+tab_width = 8
+
 [*.{yml,yaml}]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -33,10 +33,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[utils/macos/bundle-dylibs.sh]
-indent_size = 4
-tab_width = 8
-
 [*.{yml,yaml}]
 indent_style = space
 indent_size = 2

--- a/utils/macos/.editorconfig
+++ b/utils/macos/.editorconfig
@@ -1,0 +1,7 @@
+root = false
+
+[bundle-dylibs.sh]
+indent_style = tab
+indent_size = 4
+tab_width = 8
+


### PR DESCRIPTION
**Type of change**
Visual improvement

**Issue(s) closed**
Re https://github.com/widelands/widelands/pull/6356#issuecomment-1937013564

**New behavior**
Indentation of bundle-dylibs.sh look right

**Possible regressions**
indentation behaviour when editing bundle-dylibs?

**Additional context**
Seems to work... at least it displays correctly in this branch in my repo...